### PR TITLE
support for gpx without timestamp

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-gpx",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "parse gpx into json",
   "main": "index.js",
   "scripts": {

--- a/src/parseTrack.js
+++ b/src/parseTrack.js
@@ -7,7 +7,7 @@ const parseTrack = track =>  {
   var elevation = t.ele[0],
     lat = t['$'].lat,
     lng = (t['$'].lng || t['$'].lon),
-    timestamp = t.time[0],
+    timestamp = t.time ? t.time[0] : undefined,
     hr,
     cadence;
 


### PR DESCRIPTION
A pure track file (like a Strava route) does not have `timestamp`.
Can we modify the `parseTrack.js` at line `10` in this way:

    timestamp = t.time ? t.time[0] : undefined,

so to support that kind of gpx file too?